### PR TITLE
API change

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -96,9 +96,7 @@
     var flags = hasSticky ? 'ym' : 'gm'
     var regexp = new RegExp(reUnion(parts) + suffix, flags)
 
-    return function(input) {
-      return new Lexer(regexp, groups, input)
-    }
+    return new Lexer(regexp, groups)
   }
 
 
@@ -220,10 +218,7 @@
     // insert newline rule
     rules.splice(0, 0, ['NL', '\n'])
 
-    var factory = compile(rules)
-    return function(input) {
-      return new LineLexer(factory(input))
-    }
+    return new LineLexer(compile(rules))
   }
 
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -8,7 +8,7 @@ let suite = new Benchmark.Suite()
 
 
 const python = require('./python')
-let pythonFactory = moo(python.rules)
+let pythonLexer = moo(python.rules)
 let kurtFile = fs.readFileSync('test/kurt.py', 'utf-8')
 
 
@@ -46,7 +46,7 @@ suite.add('tosh', function() {
 
 /* moo! */
 suite.add('moo', function() {
-  pythonFactory(kurtFile).lexAll()
+  pythonLexer.clone().feed(kurtFile).lexAll()
 })
 
 

--- a/test/python.js
+++ b/test/python.js
@@ -55,10 +55,10 @@ var TOKENS = [
 
 ];
 
-var factory = moo(TOKENS);
+var pythonLexer = moo(TOKENS);
 
 var tokenize = function(input, emit) {
-  var lexer = factory(input);
+  var lexer = pythonLexer.clone().feed(input);
   var lex = function() { return lexer.lex(); }
 
   var tok = lex();

--- a/test/tosh.js
+++ b/test/tosh.js
@@ -1,7 +1,7 @@
 
 const moo = require('../moo')
 
-let factory = moo([
+let toshLexer = moo([
   ['WS',      /[ \t]+/],
   ['ellips',  /\.{3}/],
   ['comment', /\/{2}(.*)$/],
@@ -27,7 +27,7 @@ let factory = moo([
 ])
 
 function tokenize(source) {
-  let lexer = factory(source + '\n')
+  let lexer = toshLexer.clone().feed(source + '\n')
   return lexer.lexAll().filter(x => x.name !== 'WS').map(x => [x.name, x.value])
 }
 


### PR DESCRIPTION
Change moo() to return a Lexer instead of a factory.

So now instead of:

```js
    let factory = moo([
      ['WS',      /[ \t]+/],
      ['rparen',  ')'],
      ['keyword', ['while', 'if', 'else', 'moo', 'cows']],
      ['NL',      /\n/],
    ])

    let lexer = factory('while (10) cows\nmoo')
    lexer.lex() // -> { name: 'keyword', value: 'while' }
```

You do:

```js
    let lexer = moo([
      ['WS',      /[ \t]+/],
      ['rparen',  ')'],
      ['keyword', ['while', 'if', 'else', 'moo', 'cows']],
      ['NL',      /\n/],
    ])

    lexer.feed('while (10) cows\nmoo')
    lexer.lex() // -> { name: 'keyword', value: 'while' }
```

The thing is that now you have to explicitly reset the lexer: `lexer.rewind(0); lexer.feed(input)`. Or alternatively, `lexer.clone().feed(input)`.

Before, you could just do `factory(input)` to get a fresh lexer.