### PR TITLE
Special-case keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](cow.png)
 
-Moo!
+moo!
 ====
 
 Moo is a highly-optimised tokenizer/lexer generator. Use it to tokenize your strings, before parsing 'em with a parser like [nearley](https://github.com/hardmath123/nearley) or whatever else you're into.
@@ -101,6 +101,43 @@ RegExps are nifty for making tokenizers, but they can be a bit of a pain. Here a
 * Moo uses **multiline RegExps**. This has a few quirks: for example, `/./` doesn't include newlines. Use `[^]` instead if you want this.
 
 * Since excluding capture groups like `/[^ ]/` (no spaces) _will_ include newlines, you have to be careful not to include them by accident! In particular, the whitespace metacharacter `\s` includes newlines.
+
+
+Keywords
+--------
+
+Moo makes it convenient to define literals and keywords:
+
+```js
+      // ...
+      ['lparen',  '('],
+      ['rparen',  ')'],
+      ['keyword', ['while', 'if', 'else', 'moo', 'cows']],
+      // ...
+```
+
+It'll automatically compile them into regular expressions, escaping them where necessary.
+
+**Important!**: moo also special-cases keywords to ensure the **longest match** principle applies, even in edge cases.
+
+Imagine trying to parse the input `className` with the following rules:
+
+      ['keyword',     ['class']],
+      ['identifier',  /[a-zA-Z]+/],
+
+You'll get _two_ tokens — `['class', 'Name']` -- which is _not_ what you want! If you swap the order of the rules, you'll fix this example; but now you'll lex `class` wrong (as an `identifier`).
+
+Moo solves this by checking to see if any of your literals can be matched by one of your other rules; if so, it doesn't lex the keyword separately, but instead handles it at a later stage (by checking identifiers against a list of keywords). So you should always do this:
+
+```js
+    ['while', 'if', 'else', 'moo', 'cows']
+```
+
+and **not** this:
+
+```js
+    /while|if|else|moo|cows/
+```
 
 
 Questions

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,22 @@ describe('moo compiler', () => {
     expect(compile({ NL:  /\n/ }).reset('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
   })
 
+  test("deals with keyword literals", () => {
+    var keywordFirst = compile([
+      ['keyword',     ['class']],
+      ['identifier',  /[a-zA-Z]+/],
+    ])
+    expect(keywordFirst.reset('class').lexAll().map(t => t.name)).toEqual(['keyword'])
+    expect(keywordFirst.reset('className').lexAll().map(t => t.name)).toEqual(['identifier'])
+
+    var identifierFirst = compile([
+      ['identifier',  /[a-zA-Z]+/],
+      ['keyword',     ['class']],
+    ])
+    expect(identifierFirst.reset('class').lexAll().map(t => t.name)).toEqual(['keyword'])
+    expect(identifierFirst.reset('className').lexAll().map(t => t.name)).toEqual(['identifier'])
+  })
+
 })
 
 describe('moo lexer', () => {


### PR DESCRIPTION
Special-case keywords so that the longest-match prinicple applies, even in edge cases. This helps solve the `class` vs. `className` problem. See the [updated README](https://github.com/tjvr/moo/blob/30a89f5c372e21a368935d9675e7e84ce036ff07/README.md#keywords) for more explanation.

This has a barely-measurable (<5%) impact on the benchmarks. :-)