### PR TITLE
Accept non-Array objects as compile() ruleset

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -63,7 +63,18 @@
   }
 
 
+  function objectToRules(object) {
+    var keys = Object.keys(object)
+    var result = []
+    for (var i=0; i<keys.length; i++) {
+      var key = keys[i]
+      result.push([key, object[key]])
+    }
+    return result
+  }
+
   function compile(rules) {
+    if (!Array.isArray(rules)) rules = objectToRules(rules)
     var groups = []
     var parts = []
     for (var i=0; i<rules.length; i++) {

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,16 @@ describe('moo lexer', () => {
     expect(lexer.lex().toString()).toBe('are')
   })
 
+  test('accepts rules in an object', () => {
+    const lexer = compile({
+      word: /[a-z]+/,
+      number: /[0-9]+/,
+      space: / +/,
+    })('ducks are 123 bad')
+    expect(lexer.lex()).toMatchObject({name: 'word', value: 'ducks'})
+    expect(lexer.lex()).toMatchObject({name: 'space', value: ' '})
+  })
+
   test('no capture groups', () => {
     let factory = compile([
         ['a', /a+/],


### PR DESCRIPTION
Property names are token names, and property values are regular expressions, e.g.:

```js
{ word: /[a-z]+/, space: / +/ } <==> [ ['word', /[a-z]+/], ['space', / +/] ]
```

Closes tjvr/moo#7.