### PR TITLE
Use Object.getOwnPropertyNames instead of Object.keys

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -64,7 +64,7 @@
 
 
   function objectToRules(object) {
-    var keys = Object.keys(object)
+    var keys = Object.getOwnPropertyNames(object)
     var result = []
     for (var i=0; i<keys.length; i++) {
       var key = keys[i]


### PR DESCRIPTION
I'm not very good at this "JavaScript" thing.