### PR TITLE
Rework API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then you can start roasting your very own lexer/tokenizer:
 ```js
     const moo = require('moo')
 
-    let factory = moo([
+    let lexer = moo.compile([
       ['WS',      /[ \t]+/],
       ['comment', /\/\/.*?$/],
       ['number',  /(0|[1-9][0-9]*)/],
@@ -45,7 +45,7 @@ Then you can start roasting your very own lexer/tokenizer:
 And now throw some text at it:
 
 ```js
-    let lexer = factory('while (10) cows\nmoo')
+    lexer.reset('while (10) cows\nmoo')
     lexer.lex() // -> { name: 'keyword', value: 'while' }
     lexer.lex() // -> { name: 'WS', value: ' ' }
     lexer.lex() // -> { name: 'lparen', value: '(' }
@@ -56,9 +56,10 @@ And now throw some text at it:
 You can also feed it chunks of input at a time:
 
 ```j
-    let lexer = factory()
+    lexer.reset()
     lexer.feed('while')
     lexer.feed(' 10 cows\n')
+    lexer.lex() // -> { name: 'keyword', value: 'while' }
     // ...
 ```
 
@@ -75,7 +76,7 @@ RegExps are nifty for making tokenizers, but they can be a bit of a pain. Here a
 * You often want to use **non-greedy quantifiers**: e.g. `*?` instead of `*`. Otherwise your tokens will be longer than you expect:
 
 ```js
-    let factory = moo([
+    let lexer = moo.compile([
       ['string', /".*"/],   // greedy quantifier *
       // ...
     ])
@@ -86,15 +87,15 @@ RegExps are nifty for making tokenizers, but they can be a bit of a pain. Here a
 * The **order of your rules** matters. Earlier ones will take precedence.
 
 ```js
-    moo([
+    moo.compile([
         ['word',  /[a-z]+/],
         ['foo',   'foo'],
-    ])('foo').lexAll() // -> [{ name: 'word', value: 'foo' }]
+    ]).reset('foo').lexAll() // -> [{ name: 'word', value: 'foo' }]
 
-    moo([
+    moo.compile([
         ['foo',   'foo'],
         ['word',  /[a-z]+/],
-    ])('foo').lexAll() // -> [{ name: 'foo', value: 'foo' }]
+    ]).reset('foo').lexAll() // -> [{ name: 'foo', value: 'foo' }]
 ```
 
 * Moo uses **multiline RegExps**. This has a few quirks: for example, `/./` doesn't include newlines. Use `[^]` instead if you want this.

--- a/moo.js
+++ b/moo.js
@@ -283,7 +283,8 @@
   }
 
 
-  var moo = compile
+  var moo = {} // TODO: what should moo() do?
+  moo.compile = compile
   moo.lines = compileLines
   return moo
 

--- a/moo.js
+++ b/moo.js
@@ -107,9 +107,7 @@
     var flags = hasSticky ? 'ym' : 'gm'
     var regexp = new RegExp(reUnion(parts) + suffix, flags)
 
-    return function(input) {
-      return new Lexer(regexp, groups, input)
-    }
+    return new Lexer(regexp, groups)
   }
 
 
@@ -231,10 +229,7 @@
     // insert newline rule
     rules.splice(0, 0, ['NL', '\n'])
 
-    var factory = compile(rules)
-    return function(input) {
-      return new LineLexer(factory(input))
-    }
+    return new LineLexer(compile(rules))
   }
 
 

--- a/moo.js
+++ b/moo.js
@@ -281,10 +281,11 @@
   }
 
   LineLexer.prototype.rewindLine = function(lineno) {
+    if (lineno < 1) { throw new Error("Line 0 is out-of-bounds") }
     if (lineno > this.lineno) { throw new Error("Can't seek forwards") }
     this.lexer.rewind(this.lineIndexes[lineno])
     // TODO slice buffer
-    this.lineIndexes.splice(lineno)
+    this.lineIndexes.splice(lineno + 1)
     this.lineno = lineno
     this.col = 0
     return this

--- a/moo.js
+++ b/moo.js
@@ -203,6 +203,12 @@
     return this
   }
 
+  Lexer.prototype.reset = function(data) {
+    this.rewind(0)
+    if (data) { this.feed(data) }
+    return this
+  }
+
   Lexer.prototype.feed = function(data) {
     this.buffer += data
     return this
@@ -262,6 +268,12 @@
   }
 
   LineLexer.prototype.lexAll = Lexer.prototype.lexAll
+
+  LineLexer.prototype.reset = function(data) {
+    this.rewindLine(1)
+    if (data) { this.feed(data) }
+    return this
+  }
 
   LineLexer.prototype.feed = function(data) {
     this.lexer.feed(data)

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -8,7 +8,7 @@ let suite = new Benchmark.Suite()
 
 
 const python = require('./python')
-let pythonFactory = moo(python.rules)
+let pythonLexer = moo(python.rules)
 let kurtFile = fs.readFileSync('test/kurt.py', 'utf-8')
 
 
@@ -46,7 +46,7 @@ suite.add('tosh', function() {
 
 /* moo! */
 suite.add('moo', function() {
-  pythonFactory(kurtFile).lexAll()
+  pythonLexer.clone().feed(kurtFile).lexAll()
 })
 
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -8,7 +8,7 @@ let suite = new Benchmark.Suite()
 
 
 const python = require('./python')
-let pythonLexer = moo(python.rules)
+let pythonLexer = moo.compile(python.rules)
 let kurtFile = fs.readFileSync('test/kurt.py', 'utf-8')
 
 

--- a/test/python.js
+++ b/test/python.js
@@ -55,10 +55,10 @@ var TOKENS = [
 
 ];
 
-var factory = moo(TOKENS);
+var pythonLexer = moo(TOKENS);
 
 var tokenize = function(input, emit) {
-  var lexer = factory(input);
+  var lexer = pythonLexer.clone().feed(input);
   var lex = function() { return lexer.lex(); }
 
   var tok = lex();

--- a/test/python.js
+++ b/test/python.js
@@ -55,7 +55,7 @@ var TOKENS = [
 
 ];
 
-var pythonLexer = moo(TOKENS);
+var pythonLexer = moo.compile(TOKENS);
 
 var tokenize = function(input, emit) {
   var lexer = pythonLexer.clone().feed(input);

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,8 @@
 
 const fs = require('fs')
 
-const moo = compile = require('../moo')
+const moo = require('../moo')
+const compile = moo.compile
 const python = require('./python')
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -17,22 +17,22 @@ describe('moo compiler', () => {
 
   test("handles newline literals", () => {
     // it seems \n doesn't need to be escaped!
-    expect(compile([['NL', '\n']])('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
-    expect(compile([['NL', /\n/]])('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
+    expect(compile([['NL', '\n']]).feed('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
+    expect(compile([['NL', /\n/]]).feed('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
   })
 
 })
 
 describe('moo lexer', () => {
 
-  var simpleFactory = compile([
+  var simpleLexer = compile([
     ['word', /[a-z]+/],
     ['number', /[0-9]+/],
     [null, / +/],
   ])
 
   test('ducks', () => {
-    let lexer = simpleFactory()
+    let lexer = simpleLexer.clone()
     lexer.feed('ducks are 123 bad')
     expect(lexer.lex().toString()).toBe('ducks')
     expect(lexer.lex().toString()).toBe(' ')
@@ -44,17 +44,18 @@ describe('moo lexer', () => {
       word: /[a-z]+/,
       number: /[0-9]+/,
       space: / +/,
-    })('ducks are 123 bad')
+    })
+    lexer.feed('ducks are 123 bad')
     expect(lexer.lex()).toMatchObject({name: 'word', value: 'ducks'})
     expect(lexer.lex()).toMatchObject({name: 'space', value: ' '})
   })
 
   test('no capture groups', () => {
-    let factory = compile([
+    let lexer = compile([
         ['a', /a+/],
         ['b', /b|c/],
     ])
-    let lexer = factory('aaaaabcbcbcbc')
+    lexer.feed('aaaaabcbcbcbc')
     expect(lexer.lex().value).toEqual('aaaaa')
     expect(lexer.lex().value).toEqual('b')
     expect(lexer.lex().value).toEqual('c')
@@ -64,7 +65,7 @@ describe('moo lexer', () => {
   test('multiline', () => {
     var lexer = compile([
       ['file', /([^]+)/],
-    ])('I like to moo\na lot')
+    ]).feed('I like to moo\na lot')
     expect(lexer.lex().value).toBe('I like to moo\na lot')
   })
 
@@ -75,7 +76,7 @@ describe('moo lexer', () => {
       ['WS', / +/],
       ['NL', /\n/],
       ['other', /[^ \n]+/],
-    ])('x \n x\n yz x')
+    ]).feed('x \n x\n yz x')
     let tokens = lexer.lexAll().filter(t => t.name !== 'WS')
     expect(tokens.map(t => [t.name, t.value])).toEqual([
       ['x', 'x'],
@@ -94,7 +95,7 @@ describe('moo lexer', () => {
       ['WS', / +/],
       ['NL', /\n/],
       ['other', /[^ \n]+/],
-    ])('x \n x\nx yz')
+    ]).feed('x \n x\nx yz')
     let tokens = lexer.lexAll().filter(t => t.name !== 'WS')
     expect(tokens.map(t => [t.name, t.value])).toEqual([
       ['x-bol', 'x'],
@@ -110,13 +111,13 @@ describe('moo lexer', () => {
   // - check the reported error location
 
   test('kurt tokens', () => {
-    let pythonFactory = compile(python.rules)
-    let tokens = pythonFactory(fs.readFileSync('test/kurt.py', 'utf-8')).lexAll()
+    let pythonLexer = compile(python.rules)
+    let tokens = pythonLexer.feed(fs.readFileSync('test/kurt.py', 'utf-8')).lexAll()
     expect(tokens.length).toBe(14513)
   })
 
   test('can rewind', () => {
-    let lexer = simpleFactory()
+    let lexer = simpleLexer.clone()
     lexer.feed('ducks are 123 bad')
     expect(lexer.lex().toString()).toBe('ducks')
     expect(lexer.lex().toString()).toBe(' ')
@@ -128,7 +129,7 @@ describe('moo lexer', () => {
   })
 
   test("won't rewind forward", () => {
-    let lexer = simpleFactory()
+    let lexer = simpleLexer.clone()
     lexer.feed('ducks are 123 bad')
     expect(() => lexer.rewind(0)).not.toThrow()
     expect(() => lexer.rewind(1)).toThrow()
@@ -144,13 +145,13 @@ describe('moo lexer', () => {
 
 describe('moo line lexer', () => {
 
-  var factory = moo.lines([
+  var testLexer = moo.lines([
     ['WS', / +/],
     ['word', /[a-z]+/],
   ])
 
   test('lexes lines', () => {
-    var tokens = factory('steak\nsauce\nparty').lexAll()
+    var tokens = testLexer.clone().feed('steak\nsauce\nparty').lexAll()
     expect(tokens.map(t => t.value)).toEqual(['steak', '\n', 'sauce', '\n', 'party'])
     expect(tokens.map(t => t.lineno)).toEqual([1, 1, 2, 2, 3])
     expect(tokens.map(t => t.col)).toEqual([0, 5, 0, 5, 0])
@@ -162,7 +163,7 @@ describe('moo line lexer', () => {
   })
 
   test('can rewind to line', () => {
-    var lexer = factory('steak\nsauce\nparty')
+    var lexer = testLexer.clone().feed('steak\nsauce\nparty')
     expect(lexer.lex().value).toBe('steak')
     expect(lexer.lex().value).toBe('\n')
     expect(lexer.lex().value).toBe('sauce')
@@ -178,7 +179,7 @@ describe('moo line lexer', () => {
   })
 
   test("won't rewind forward", () => {
-    var lexer = factory('steak\nsauce\nparty')
+    var lexer = testLexer.clone().feed('steak\nsauce\nparty')
     expect(() => lexer.rewindLine(0)).not.toThrow()
     expect(() => lexer.rewindLine(1)).toThrow()
     expect(lexer.lex().value).toBe('steak')
@@ -206,8 +207,8 @@ describe('python tokenizer', () => {
   // use non-greedy matching
   test('triple-quoted strings', () => {
     let example = '"""abc""" 1+1 """def"""'
-    let pythonFactory = compile(python.rules)
-    expect(pythonFactory(example).lexAll().map(t => t.value)).toEqual(
+    let pythonLexer = compile(python.rules)
+    expect(pythonLexer.feed(example).lexAll().map(t => t.value)).toEqual(
       ['"""abc"""', " ", "1", "+", "1", " ", '"""def"""']
     )
   })

--- a/test/test.js
+++ b/test/test.js
@@ -160,6 +160,19 @@ describe('moo line lexer', () => {
     expect(() => moo.lines([['multiline', /q[^]*/]])).not.toThrow()
   })
 
+  test('resets', () => {
+    var lexer = moo.lines([
+      ['WS', / +/],
+      ['word', /[a-z]+/],
+    ])
+    lexer.reset('potatoes')
+    expect(lexer.lineIndexes).toEqual([-1, 0])
+    expect(lexer.lexer.buffer).toBe('potatoes')
+    lexer.reset('cheesecake')
+    expect(lexer.lineIndexes).toEqual([-1, 0])
+    expect(lexer.lexer.buffer).toBe('cheesecake')
+  })
+
   test('can rewind to line', () => {
     var lexer = testLexer.clone().feed('steak\nsauce\nparty')
     expect(lexer.lex().value).toBe('steak')
@@ -176,15 +189,21 @@ describe('moo line lexer', () => {
     expect(lexer.lex()).toBe(undefined)
   })
 
+  test("can't rewind before line 1", () => {
+    var lexer = testLexer.reset('cow')
+    expect(() => lexer.rewindLine(0)).toThrow()
+  })
+
   test("won't rewind forward", () => {
-    var lexer = testLexer.clone().feed('steak\nsauce\nparty')
-    expect(() => lexer.rewindLine(0)).not.toThrow()
-    expect(() => lexer.rewindLine(1)).toThrow()
+    var lexer = testLexer.reset('steak\nsauce\nparty')
+    expect(() => lexer.rewindLine(1)).not.toThrow()
+    expect(() => lexer.rewindLine(2)).toThrow()
+    lexer.reset('steak\nsauce\nparty')
     expect(lexer.lex().value).toBe('steak')
     expect(lexer.lex().value).toBe('\n')
     expect(lexer.lex().value).toBe('sauce')
-    lexer.rewindLine(0)
-    expect(() => lexer.rewindLine(1)).toThrow()
+    lexer.rewindLine(1)
+    expect(() => lexer.rewindLine(2)).toThrow()
   })
 
   // TODO test clone()

--- a/test/test.js
+++ b/test/test.js
@@ -18,8 +18,8 @@ describe('moo compiler', () => {
 
   test("handles newline literals", () => {
     // it seems \n doesn't need to be escaped!
-    expect(compile([['NL', '\n']]).feed('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
-    expect(compile([['NL', /\n/]]).feed('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
+    expect(compile([['NL', '\n']]).reset('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
+    expect(compile([['NL', /\n/]]).reset('\n\n').lexAll().map(t => t.name)).toEqual(['NL', 'NL'])
   })
 
 })
@@ -33,8 +33,7 @@ describe('moo lexer', () => {
   ])
 
   test('ducks', () => {
-    let lexer = simpleLexer.clone()
-    lexer.feed('ducks are 123 bad')
+    let lexer = simpleLexer.reset('ducks are 123 bad')
     expect(lexer.lex().toString()).toBe('ducks')
     expect(lexer.lex().toString()).toBe(' ')
     expect(lexer.lex().toString()).toBe('are')
@@ -46,7 +45,7 @@ describe('moo lexer', () => {
       number: /[0-9]+/,
       space: / +/,
     })
-    lexer.feed('ducks are 123 bad')
+    lexer.reset('ducks are 123 bad')
     expect(lexer.lex()).toMatchObject({name: 'word', value: 'ducks'})
     expect(lexer.lex()).toMatchObject({name: 'space', value: ' '})
   })
@@ -56,7 +55,7 @@ describe('moo lexer', () => {
         ['a', /a+/],
         ['b', /b|c/],
     ])
-    lexer.feed('aaaaabcbcbcbc')
+    lexer.reset('aaaaabcbcbcbc')
     expect(lexer.lex().value).toEqual('aaaaa')
     expect(lexer.lex().value).toEqual('b')
     expect(lexer.lex().value).toEqual('c')
@@ -66,7 +65,7 @@ describe('moo lexer', () => {
   test('multiline', () => {
     var lexer = compile([
       ['file', /([^]+)/],
-    ]).feed('I like to moo\na lot')
+    ]).reset('I like to moo\na lot')
     expect(lexer.lex().value).toBe('I like to moo\na lot')
   })
 
@@ -77,7 +76,7 @@ describe('moo lexer', () => {
       ['WS', / +/],
       ['NL', /\n/],
       ['other', /[^ \n]+/],
-    ]).feed('x \n x\n yz x')
+    ]).reset('x \n x\n yz x')
     let tokens = lexer.lexAll().filter(t => t.name !== 'WS')
     expect(tokens.map(t => [t.name, t.value])).toEqual([
       ['x', 'x'],
@@ -96,7 +95,7 @@ describe('moo lexer', () => {
       ['WS', / +/],
       ['NL', /\n/],
       ['other', /[^ \n]+/],
-    ]).feed('x \n x\nx yz')
+    ]).reset('x \n x\nx yz')
     let tokens = lexer.lexAll().filter(t => t.name !== 'WS')
     expect(tokens.map(t => [t.name, t.value])).toEqual([
       ['x-bol', 'x'],
@@ -113,13 +112,12 @@ describe('moo lexer', () => {
 
   test('kurt tokens', () => {
     let pythonLexer = compile(python.rules)
-    let tokens = pythonLexer.feed(fs.readFileSync('test/kurt.py', 'utf-8')).lexAll()
+    let tokens = pythonLexer.reset(fs.readFileSync('test/kurt.py', 'utf-8')).lexAll()
     expect(tokens.length).toBe(14513)
   })
 
   test('can rewind', () => {
-    let lexer = simpleLexer.clone()
-    lexer.feed('ducks are 123 bad')
+    let lexer = simpleLexer.reset('ducks are 123 bad')
     expect(lexer.lex().toString()).toBe('ducks')
     expect(lexer.lex().toString()).toBe(' ')
     expect(lexer.lex().toString()).toBe('are')
@@ -130,8 +128,7 @@ describe('moo lexer', () => {
   })
 
   test("won't rewind forward", () => {
-    let lexer = simpleLexer.clone()
-    lexer.feed('ducks are 123 bad')
+    let lexer = simpleLexer.reset('ducks are 123 bad')
     expect(() => lexer.rewind(0)).not.toThrow()
     expect(() => lexer.rewind(1)).toThrow()
     lexer.feed('ducks are 123 bad')
@@ -209,7 +206,7 @@ describe('python tokenizer', () => {
   test('triple-quoted strings', () => {
     let example = '"""abc""" 1+1 """def"""'
     let pythonLexer = compile(python.rules)
-    expect(pythonLexer.feed(example).lexAll().map(t => t.value)).toEqual(
+    expect(pythonLexer.reset(example).lexAll().map(t => t.value)).toEqual(
       ['"""abc"""', " ", "1", "+", "1", " ", '"""def"""']
     )
   })

--- a/test/tosh.js
+++ b/test/tosh.js
@@ -1,7 +1,7 @@
 
 const moo = require('../moo')
 
-let factory = moo([
+let toshLexer = moo([
   ['WS',      /[ \t]+/],
   ['ellips',  /\.{3}/],
   ['comment', /\/{2}(.*)$/],
@@ -27,7 +27,7 @@ let factory = moo([
 ])
 
 function tokenize(source) {
-  let lexer = factory(source + '\n')
+  let lexer = toshLexer.clone().feed(source + '\n')
   return lexer.lexAll().filter(x => x.name !== 'WS').map(x => [x.name, x.value])
 }
 

--- a/test/tosh.js
+++ b/test/tosh.js
@@ -1,7 +1,7 @@
 
 const moo = require('../moo')
 
-let toshLexer = moo([
+let toshLexer = moo.compile([
   ['WS',      /[ \t]+/],
   ['ellips',  /\.{3}/],
   ['comment', /\/{2}(.*)$/],


### PR DESCRIPTION
* Return a Lexer instead of a factory -- fixes #8.
* Rename moo() -> moo.compile()
* Add Lexer::reset()