### PR TITLE
Burn LineLexer

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -112,6 +112,11 @@
         throw new Error("RegExp has more than one capture group: " + regexp)
       }
 
+      // try and detect rules matching newlines
+      if (!options.lineBreaks && regexp.test('\n')) {
+        throw new Error('Rule should declare lineBreaks: ' + regexp)
+      }
+
       // store regex
       var isCapture = !!groupCount
       if (!isCapture) pat = reCapture(pat)
@@ -195,8 +200,12 @@
     var lineBreaks = 0
     if (group.lineBreaks) {
       var re = /\n/g
-      var nl
-      while (re.exec(text)) { lineBreaks++; nl = re.lastIndex }
+      var nl = 1
+      if (text === '\n') {
+        lineBreaks = 1
+      } else {
+        while (re.exec(text)) { lineBreaks++; nl = re.lastIndex }
+      }
     }
 
     var size = text.length

--- a/moo.js
+++ b/moo.js
@@ -11,6 +11,8 @@
 
   var hasSticky = typeof new RegExp().sticky === 'boolean'
 
+  function isRegExp(o) { return o && o.constructor === RegExp }
+
 
   function reEscape(s) {
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
@@ -38,7 +40,7 @@
     if (typeof obj === 'string') {
       return '(?:' + reEscape(obj) + ')'
 
-    } else if (obj && obj.constructor === RegExp) {
+    } else if (isRegExp(obj)) {
       // TODO: consider /u support
       if (obj.ignoreCase) { throw new Error('RegExp /i flag not allowed') }
       if (obj.global) { throw new Error('RegExp /g flag is implied') }
@@ -85,27 +87,35 @@
     for (var i=0; i<rules.length; i++) {
       var rule = rules[i]
       var name = rule[0]
-      var re = rule[1]
+      var obj = rule[1]
 
-      // convert string literal to RegExp
-      re = pattern(re)
+      // get options
+      if (typeof obj !== 'object' || Array.isArray(obj) || isRegExp(obj)) {
+        obj = { match: obj }
+      }
+      var options = Object.assign({
+        name: name,
+        lineBreaks: false,
+      }, obj)
+      groups.push(options)
+
+      // convert to RegExp
+      var pat = pattern(obj.match)
 
       // validate
-      if (new RegExp(re).test("")) {
-        throw new Error("RegExp matches empty string: " + new RegExp(re))
+      var regexp = new RegExp(pat)
+      if (regexp.test("")) {
+        throw new Error("RegExp matches empty string: " + regexp)
       }
-
-      // store named group
-      var groupCount = reGroups(re)
+      var groupCount = reGroups(pat)
       if (groupCount > 1) {
-        throw new Error("RegExp has more than one capture group: " + re)
+        throw new Error("RegExp has more than one capture group: " + regexp)
       }
-      groups.push(name)
 
       // store regex
       var isCapture = !!groupCount
-      if (!isCapture) re = reCapture(re)
-      parts.push(re)
+      if (!isCapture) pat = reCapture(pat)
+      parts.push(pat)
     }
 
     var suffix = hasSticky ? '' : '|(?:)'
@@ -117,9 +127,17 @@
 
 
   var Lexer = function(re, groups) {
-    this.buffer = ''
     this.groups = groups
     this.re = re
+
+    this.buffer = ''
+    this.lineno = 1
+    this.col = 0
+  }
+
+  Lexer.error = {
+    name: 'ERRORTOKEN',
+    lineBreaks: true,
   }
 
   Lexer.prototype.eat = hasSticky ? function(re) {
@@ -151,38 +169,55 @@
 
     var start = re.lastIndex
     var match = this.eat(re)
+    var group, value, text
     if (match === null) {
-      var remaining = buffer.slice(start)
-      var token = {
-        type: 'ERRORTOKEN',
-        value: remaining,
-        size: remaining.length,
-        offset: start,
-        toString: tokenToString,
-      }
+      group = Lexer.error
+
+      // consume rest of buffer
+      text = value = buffer.slice(start)
       re.lastIndex = buffer.length
-      return token
-    }
 
-    var groups = this.groups
-    var group
-    for (var i = 0; i < groups.length; i++) {
-      var value = match[i + 1]
-      if (value !== undefined) {
-        group = groups[i]
-        break
+    } else {
+      text = match[0]
+      var groups = this.groups
+      for (var i = 0; i < groups.length; i++) {
+        var value = match[i + 1]
+        if (value !== undefined) {
+          group = groups[i]
+          break
+        }
       }
+      // assert(i < groupCount)
+      // TODO is `buffer` being leaked here?
     }
-    // assert(i < groupCount)
-    // TODO is `buffer` being leaked here?
 
-    return {
-      type: group,
-      value: value,
-      size: match[0].length,
-      offset: re.lastIndex,
-      toString: tokenToString,
+    // count line breaks
+    var lineBreaks = 0
+    if (group.lineBreaks) {
+      var re = /\n/g
+      var nl
+      while (re.exec(text)) { lineBreaks++; nl = re.lastIndex }
     }
+
+    var size = text.length
+    var token = {
+      type: group.name,
+      value: value,
+      toString: tokenToString,
+      offset: start,
+      size: size,
+      lineBreaks: lineBreaks,
+      lineno: this.lineno,
+      col: this.col,
+    }
+
+    this.lineno += lineBreaks
+    if (lineBreaks !== 0) {
+      this.col = size - nl
+    } else {
+      this.col += size
+    }
+    return token
   }
 
   Lexer.prototype.lexAll = function() {
@@ -198,18 +233,16 @@
     return this.re.lastIndex
   }
 
-  Lexer.prototype.rewind = function(index) {
-    if (index > this.buffer.length) {
-      throw new Error("Can't seek forwards")
+  Lexer.prototype.reset = function(data, token) {
+    this.buffer = data || ''
+    this.re.lastIndex = 0
+    this.lineno = 1
+    this.col = 0
+    if (token) {
+      this.lineno = token.lineno
+      this.col = token.col
+      // TODO copy states
     }
-    this.re.lastIndex = index
-    this.buffer = this.buffer.slice(0, index)
-    return this
-  }
-
-  Lexer.prototype.reset = function(data) {
-    this.rewind(0)
-    if (data) { this.feed(data) }
     return this
   }
 
@@ -228,83 +261,8 @@
   }
 
 
-  function compileLines(rules) {
-    if (!Array.isArray(rules)) rules = objectToRules(rules)
-
-    // try and detect rules matching newlines
-    for (var i = 0; i < rules.length; i++) {
-      var pat = rules[i][1]
-      if (pat instanceof RegExp && pat.test('\n')) {
-        throw new Error('RegExp matches newline: ' + pat)
-      }
-    }
-    // insert newline rule
-    rules.splice(0, 0, ['NL', '\n'])
-
-    return new LineLexer(compile(rules))
-  }
-
-
-  var LineLexer = function(lexer) {
-    this.lexer = lexer
-
-    this.lineIndexes = [-1, 0] // 1-based
-    this.lineno = 1
-    this.col = 0
-  }
-
-  LineLexer.prototype.lex = function() {
-    var tok = this.lexer.lex()
-    if (!tok) {
-      return tok
-    }
-    tok.lineno = this.lineno
-    tok.col = this.col
-
-    if (tok.type === 'NL') {
-      this.lineno++
-      this.col = 0
-      this.lineIndexes.push(this.lexer.index())
-    } else {
-      this.col += tok.size
-    }
-
-    // TODO handle error tokens
-    return tok
-  }
-
-  LineLexer.prototype.lexAll = Lexer.prototype.lexAll
-
-  LineLexer.prototype.reset = function(data) {
-    this.rewindLine(1)
-    if (data) { this.feed(data) }
-    return this
-  }
-
-  LineLexer.prototype.feed = function(data) {
-    this.lexer.feed(data)
-    return this
-  }
-
-  LineLexer.prototype.rewindLine = function(lineno) {
-    if (lineno < 1) { throw new Error("Line 0 is out-of-bounds") }
-    if (lineno > this.lineno) { throw new Error("Can't seek forwards") }
-    this.lexer.rewind(this.lineIndexes[lineno])
-    // TODO slice buffer
-    this.lineIndexes.splice(lineno + 1)
-    this.lineno = lineno
-    this.col = 0
-    return this
-  }
-
-  LineLexer.prototype.clone = function(input) {
-    return new LineLexer(this.lexer.clone(input))
-  }
-
-
   var moo = {} // TODO: what should moo() do?
   moo.compile = compile
-  moo.lines = compileLines
   return moo
 
 }))

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -24,7 +24,7 @@ for (let [name, pat] of python.rules) {
   if (pat instanceof Array) {
     groups.push({ name: name, regexp: pat.map(reEscape).join('|') })
   } else {
-    groups.push({ name: name, regexp: reEscape(pat) })
+    groups.push({ name: name, regexp: reEscape(pat.match || pat) })
   }
 }
 

--- a/test/python.js
+++ b/test/python.js
@@ -37,7 +37,7 @@ var TOKENS = [
   ['NAME', /([A-Za-z_][A-Za-z0-9_]*)/],
   ['OP', opPat],
   ['COMMENT', /(#.*)/],
-  ['NEWLINE', /\r|\r\n|\n/],
+  ['NEWLINE', { match: /\r|\r\n|\n/, lineBreaks: true }],
   ['Continuation', /\\/],
 
   ['ERRORTOKEN', /[\$?`]/],

--- a/test/test.js
+++ b/test/test.js
@@ -189,6 +189,11 @@ describe('line numbers', () => {
     expect(lexer.lex()).toMatchObject({ value: ' ', col: 0, lineno: 3 })
   })
 
+  test('tries to warn if rule matches \\n', () => {
+    expect(() => compile([['whitespace', /\s+/]])).toThrow()
+    expect(() => compile([['multiline', /q[^]*/]])).not.toThrow()
+  })
+
   test('resets', () => {
     var lexer = compile({
       WS: / +/,

--- a/test/tosh.js
+++ b/test/tosh.js
@@ -23,7 +23,7 @@ let toshLexer = moo.compile([
   ['symbol',  /[-%#+*/=^,?]/],                // single character
   ['symbol',  /[_A-Za-z][-_A-Za-z0-9:',.]*/], // word, as in a block
   ['iden',    /[^\n \t"'()<>=*\/+-]+/],     // user-defined names
-  ['NL',      /\n/],
+  ['NL',      { match: /\n/, lineBreaks: true }],
 ])
 
 function tokenize(source) {


### PR DESCRIPTION
* Support extra options on a rule:

```js
moo.compile({
    word: /[a-z]+/
    comment: { match: /\(\*[^]*\*\)/, lineBreaks: true },
})
```

* Remove rewind() for now, as per #12
* Add `token` argument to reset()
* If a rule has the `lineBreaks` option set, then update `lineno` appropriately. This helps keep tokenization fast; we don't have to re-scan the token looking for line breaks except for tokens which really are multiline.