### PR TITLE
Add error tokens

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -101,7 +101,8 @@
     }, obj)
 
     // convert to array
-    if (options.match && !Array.isArray(options.match)) { options.match = [options.match] }
+    var match = options.match
+    options.match = Array.isArray(match) ? match : match ? [match] : []
     return options
   }
 
@@ -113,19 +114,6 @@
       // get options
       var options = ruleOptions(rule[0], rule[1])
       var match = options.match
-
-      // add error rule
-      if (options.error) {
-        var errorOptions = Object.assign({}, options)
-        delete errorOptions.match
-        result.push(errorOptions)
-
-        // error rule may also match patterns
-        if (!options.match) {
-          continue
-        }
-        delete options.error
-      }
 
       // sort literals by length to ensure longest match
       var capturingPatterns = []
@@ -141,9 +129,7 @@
 
       // append regexps to the end
       options.match = literals.concat(patterns)
-      if (options.match.length) {
-        result.push(options)
-      }
+      result.push(options)
 
       // add each capturing regexp as a separate rule
       for (var j=0; j<capturingPatterns.length; j++) {
@@ -165,15 +151,19 @@
     var parts = []
     for (var i=0; i<rules.length; i++) {
       var options = rules[i]
-      groups.push(options)
 
       if (options.error) {
         if (errorRule) {
           throw new Error("Multiple error rules not allowed: (for token '" + options.name + "')")
         }
         errorRule = options
+      }
+
+      // skip rules with no match
+      if (options.match.length === 0) {
         continue
       }
+      groups.push(options)
 
       // convert to RegExp
       var pat = reUnion(options.match.map(regexpOrLiteral))

--- a/moo.js
+++ b/moo.js
@@ -35,8 +35,6 @@
 
   function isRegExp(o) { return o && o.constructor === RegExp }
 
-  var ERROR = {error: true}
-  Object.freeze(ERROR)
 
   function reEscape(s) {
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
@@ -92,12 +90,14 @@
       obj = { match: obj }
     }
 
+    // nb. error implies lineBreaks
     var options = assign({
       name: name,
-      lineBreaks: false,
+      lineBreaks: !!obj.error,
       pop: false,
       next: null,
       push: null,
+      error: false,
     }, obj)
 
     // convert to array
@@ -169,14 +169,13 @@
 
       if (options.error) {
         if (errorRule) {
-          throw new Error("Cannot have multiple error rules")
+          throw new Error("Multiple error rules not allowed: (for token '" + options.name + "')")
         }
         errorRule = options
         continue
       }
 
       // convert to RegExp
-      if (options.match[0] === undefined) console.log(options)
       var pat = reUnion(options.match.map(regexpOrLiteral))
 
       // validate
@@ -301,6 +300,7 @@
     if (match === null) {
       group = this.error
       if (!group) {
+        // TODO prettier syntax errors
         throw new Error('Syntax error')
       }
 
@@ -420,7 +420,7 @@
   return {
     compile: compile,
     states: compileStates,
-    error: ERROR,
+    error: Object.freeze({error: true}),
   }
 
 }))

--- a/moo.js
+++ b/moo.js
@@ -411,6 +411,7 @@
       map[key] = {
         groups: s.groups,
         regexp: new RegExp(s.regexp.source, s.regexp.flags),
+        error: this.error,
       }
     }
     return new Lexer(map, this.state, input)

--- a/test/python.js
+++ b/test/python.js
@@ -53,6 +53,7 @@ var TOKENS = [
   ["STRING", /"((?:\\["\\rn]|[^"\\])*?)"/], // strings are backslash-escaped
   ["STRING", /'((?:\\['\\rn]|[^'\\])*?)'/],
 
+  ['ERRORTOKEN', moo.error],
 ];
 
 var pythonLexer = moo.compile(TOKENS);

--- a/test/test.js
+++ b/test/test.js
@@ -347,6 +347,7 @@ describe('line numbers', () => {
     var lexer = compile({
       WS: / +/,
       word: /[a-z]+/,
+      NL: { match: '\n', lineBreaks: true },
     })
     lexer.reset('potatoes\nsalad')
     expect(lexer).toMatchObject({buffer: 'potatoes\nsalad', line: 1, col: 1})

--- a/test/test.js
+++ b/test/test.js
@@ -381,6 +381,41 @@ describe('save/restore', () => {
 })
 
 
+describe('errors', () => {
+
+  test('are thrown by default', () => {
+    let lexer = compile({
+      digits: /[0-9]+/,
+    })
+    lexer.reset('123foo')
+    expect(lexer.lex()).toMatchObject({value: '123'})
+    expect(() => lexer.lex()).toThrow()
+  })
+
+  test('can be tokens', () => {
+    let lexer = compile({
+      digits: /[0-9]+/,
+      error: moo.error,
+    })
+    expect(lexer.error).toMatchObject({name: 'error'})
+    lexer.reset('123foo')
+    expect(lexer.lex()).toMatchObject({type: 'digits', value: '123'})
+    expect(lexer.lex()).toMatchObject({type: 'error', value: 'foo'})
+  })
+
+  test('can contain line breaks', () => {
+    let lexer = compile({
+      digits: /[0-9]+/,
+      error: { error: true, lineBreaks: true },
+    })
+    lexer.reset('foo\nbar')
+    expect(lexer.lex()).toMatchObject({type: 'error', value: 'foo\nbar', lineBreaks: 1})
+    expect(lexer.lex()).toBe(undefined) // consumes rest of input
+  })
+
+})
+
+
 describe('python tokenizer', () => {
 
   test("1 + 2", () => {

--- a/test/tosh.js
+++ b/test/tosh.js
@@ -24,6 +24,7 @@ let toshLexer = moo.compile([
   ['symbol',  /[_A-Za-z][-_A-Za-z0-9:',.]*/], // word, as in a block
   ['iden',    /[^\n \t"'()<>=*\/+-]+/],     // user-defined names
   ['NL',      { match: /\n/, lineBreaks: true }],
+  ['ERROR',   moo.error],
 ])
 
 function tokenize(source) {


### PR DESCRIPTION
A proposed scheme for #18.

By default, if no token matches, moo will throw a syntax error.

Unless you define one of your tokens to match the special pattern `moo.error`, in one of the following ways:

```js
myError: moo.error

myError: { match: moo.error }

myError: { match: [/[`$\t]/, moo.error] }
```

...in which case, moo will instead return a token object with `type: myError`, with the value being the remainder of the input buffer.