### PR TITLE
Split out capturing RegExps from array

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -36,19 +36,6 @@
     return b.length - a.length
   }
 
-  function sortPatterns(array) {
-    // sort literals by length to ensure longest match
-    var regexps = []
-    var literals = []
-    for (var i=0; i<array.length; i++) {
-      var obj = array[i]
-      ;(isRegExp(obj) ? regexps : literals).push(obj)
-    }
-    literals.sort(compareLength)
-    // append regexps to the end
-    return literals.concat(regexps)
-  }
-
   function regexpOrLiteral(obj) {
     if (typeof obj === 'string') {
       return '(?:' + reEscape(obj) + ')'
@@ -66,21 +53,6 @@
     }
   }
 
-  function pattern(obj) {
-    if (typeof obj === 'string') {
-      return '(' + reEscape(obj) + ')'
-
-    } else if (Array.isArray(obj)) {
-      // sort to help ensure longest match
-      var options = sortPatterns(obj)
-      return '(' + options.map(regexpOrLiteral).join('|') + ')'
-
-    } else {
-      return regexpOrLiteral(obj)
-    }
-  }
-
-
   function objectToRules(object) {
     var keys = Object.getOwnPropertyNames(object)
     var result = []
@@ -91,30 +63,73 @@
     return result
   }
 
+  function ruleOptions(name, obj) {
+    if (typeof obj !== 'object' || Array.isArray(obj) || isRegExp(obj)) {
+      obj = { match: obj }
+    }
+    return Object.assign({
+      name: name,
+      lineBreaks: false,
+      pop: false,
+      next: null,
+      push: null,
+    }, obj)
+  }
+
+  function sortRules(rules) {
+    var result = []
+    for (var i=0; i<rules.length; i++) {
+      var rule = rules[i]
+
+      // get options
+      var options = ruleOptions(rule[0], rule[1])
+
+      // convert to array
+      var match = options.match
+      if (!Array.isArray(match)) { match = [match] }
+
+      // sort literals by length to ensure longest match
+      var capturingRegexps = []
+      var regexps = []
+      var literals = []
+      for (var j=0; j<match.length; j++) {
+        var obj = match[j]
+        if (isRegExp(obj)) {
+          if (reGroups(obj.source) === 0) regexps.push(obj)
+          else capturingRegexps.push(obj)
+        } else literals.push(obj)
+      }
+      literals.sort(compareLength)
+
+      // append regexps to the end
+      options.match = literals.concat(regexps)
+      if (options.match.length) {
+        result.push(options)
+      }
+
+      // add each capturing regexp as a separate rule
+      for (var j=0; j<capturingRegexps.length; j++) {
+        result.push(Object.assign({}, options, {
+          match: [capturingRegexps[j]],
+        }))
+      }
+    }
+    return result
+  }
+
   function compileRules(rules, hasStates) {
     if (!Array.isArray(rules)) rules = objectToRules(rules)
+
+    rules = sortRules(rules)
+
     var groups = []
     var parts = []
     for (var i=0; i<rules.length; i++) {
-      var rule = rules[i]
-      var name = rule[0]
-      var obj = rule[1]
-
-      // get options
-      if (typeof obj !== 'object' || Array.isArray(obj) || isRegExp(obj)) {
-        obj = { match: obj }
-      }
-      var options = Object.assign({
-        name: name,
-        lineBreaks: false,
-        pop: false,
-        next: null,
-        push: null,
-      }, obj)
+      var options = rules[i]
       groups.push(options)
 
       // convert to RegExp
-      var pat = pattern(obj.match)
+      var pat = reUnion(options.match.map(regexpOrLiteral))
 
       // validate
       var regexp = new RegExp(pat)
@@ -126,7 +141,7 @@
         throw new Error("RegExp has more than one capture group: " + regexp)
       }
       if (!hasStates && (options.pop || options.push || options.next)) {
-        throw new Error("State-switching options are not allowed in stateless lexers (for token '" + name + "')")
+        throw new Error("State-switching options are not allowed in stateless lexers (for token '" + options.name + "')")
       }
 
       // try and detect rules matching newlines

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,12 @@ describe('moo compiler', () => {
     expect(lexer.re.source.replace(/[(?:)]/g, '')).toBe('token|tok|t[ok]+|\\w')
   })
 
+  test('allows list of RegExps', () => {
+    expect(() => moo.compile({
+      tok: [/(foo)/, /(bar)/]
+    })).not.toThrow()
+  })
+
   test('warns about missing states', () => {
     const rules = [
       {match: '=', next: 'missing'},


### PR DESCRIPTION
For #26.

This refactors compilation so that regexps with capturing groups get treated as separate rules, whereas  other regexps and literals can be combined as before.

It also makes compilation significantly slower (5,338 ops/sec vs. 8,400, on a slow machine), but since compilation is already pretty fast, that's probably okay.