### PR TITLE
Special-case keywords, take two

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,6 @@ module.exports = {
         ],
         "lines-around-comment": "error",
         "lines-around-directive": "error",
-        "max-depth": "error",
         "max-nested-callbacks": "error",
         "max-params": "error",
         "max-statements": "off",

--- a/README.md
+++ b/README.md
@@ -116,6 +116,43 @@ RegExps are nifty for making tokenizers, but they can be a bit of a pain. Here a
 * Since excluding capture groups like `/[^ ]/` (no spaces) _will_ include newlines, you have to be careful not to include them by accident! In particular, the whitespace metacharacter `\s` includes newlines.
 
 
+Keywords
+--------
+
+Moo makes it convenient to define literals and keywords:
+
+```js
+      // ...
+      ['lparen',  '('],
+      ['rparen',  ')'],
+      ['keyword', ['while', 'if', 'else', 'moo', 'cows']],
+      // ...
+```
+
+It'll automatically compile them into regular expressions, escaping them where necessary.
+
+**Important!**: moo also special-cases keywords to ensure the **longest match** principle applies, even in edge cases.
+
+Imagine trying to parse the input `className` with the following rules:
+
+      ['keyword',     ['class']],
+      ['identifier',  /[a-zA-Z]+/],
+
+You'll get _two_ tokens — `['class', 'Name']` -- which is _not_ what you want! If you swap the order of the rules, you'll fix this example; but now you'll lex `class` wrong (as an `identifier`).
+
+Moo solves this by checking to see if any of your literals can be matched by one of your other rules; if so, it doesn't lex the keyword separately, but instead handles it at a later stage (by checking identifiers against a list of keywords). So you should always do this:
+
+```js
+    ['while', 'if', 'else', 'moo', 'cows']
+```
+
+and **not** this:
+
+```js
+    /while|if|else|moo|cows/
+```
+
+
 States
 ------
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ RegExps are nifty for making tokenizers, but they can be a bit of a pain. Here a
 Keywords
 --------
 
-Moo makes it convenient to define literals and keywords:
+Moo makes it convenient to define literals and keywords.
 
 ```js
       // ...
@@ -131,7 +131,19 @@ Moo makes it convenient to define literals and keywords:
 
 It'll automatically compile them into regular expressions, escaping them where necessary.
 
-**Important!**: moo also special-cases keywords to ensure the **longest match** principle applies, even in edge cases.
+Important! **Always write your literals like this:**
+
+```js
+    ['while', 'if', 'else', 'moo', 'cows']
+```
+
+And **not** like this:
+
+```js
+    /while|if|else|moo|cows/
+```
+
+The reason: moo special-cases keywords to ensure the **longest match** principle applies, even in edge cases.
 
 Imagine trying to parse the input `className` with the following rules:
 
@@ -140,17 +152,7 @@ Imagine trying to parse the input `className` with the following rules:
 
 You'll get _two_ tokens — `['class', 'Name']` -- which is _not_ what you want! If you swap the order of the rules, you'll fix this example; but now you'll lex `class` wrong (as an `identifier`).
 
-Moo solves this by checking to see if any of your literals can be matched by one of your other rules; if so, it doesn't lex the keyword separately, but instead handles it at a later stage (by checking identifiers against a list of keywords). So you should always do this:
-
-```js
-    ['while', 'if', 'else', 'moo', 'cows']
-```
-
-and **not** this:
-
-```js
-    /while|if|else|moo|cows/
-```
+Moo solves this by checking to see if any of your literals can be matched by one of your other rules; if so, it doesn't lex the keyword separately, but instead handles it at a later stage (by checking identifiers against a list of keywords).
 
 
 States

--- a/moo.js
+++ b/moo.js
@@ -142,17 +142,16 @@
     return result
   }
 
-  function isKeyword(literal, otherRules) {
+  function getIdentifier(literal, otherRules) {
     for (var i=0; i<otherRules.length; i++) {
       var rule = otherRules[i]
       var match = rule.match
       for (var j=0; j<match.length; j++) {
         var pat = match[j]
-        if (isRegExp(pat)) {
-          var m = pat.exec(literal)
-          if (m && m[0] === literal) {
-            return rule
-          }
+        if (!isRegExp(pat)) { continue }
+        var m = pat.exec(literal)
+        if (m && m[0] === literal) {
+          return rule
         }
       }
     }
@@ -183,7 +182,7 @@
         var word = match[j]
         if (typeof word === 'string') {
           // does it match an existing rule (e.g. identifier?)
-          var other = isKeyword(word, rules)
+          var other = getIdentifier(word, rules)
           if (other) {
             if (!other.keywords) {
               other.keywords = Object.create(null)

--- a/moo.js
+++ b/moo.js
@@ -99,6 +99,7 @@
       push: null,
       error: false,
     }, obj)
+    options.keywords = null
 
     // convert to array
     var match = options.match
@@ -141,6 +142,22 @@
     return result
   }
 
+  function isKeyword(literal, otherRules) {
+    for (var i=0; i<otherRules.length; i++) {
+      var rule = otherRules[i]
+      var match = rule.match
+      for (var j=0; j<match.length; j++) {
+        var pat = match[j]
+        if (isRegExp(pat)) {
+          var m = pat.exec(literal)
+          if (m && m[0] === literal) {
+            return rule
+          }
+        }
+      }
+    }
+  }
+
   function compileRules(rules, hasStates) {
     if (!Array.isArray(rules)) rules = objectToRules(rules)
 
@@ -158,6 +175,26 @@
         }
         errorRule = options
       }
+
+      // look for keywords
+      var match = options.match
+      var notKeywords = []
+      for (var j=0; j<match.length; j++) {
+        var word = match[j]
+        if (typeof word === 'string') {
+          // does it match an existing rule (e.g. identifier?)
+          var other = isKeyword(word, rules)
+          if (other) {
+            if (!other.keywords) {
+              other.keywords = Object.create(null)
+            }
+            other.keywords[word] = options
+            continue
+          }
+        }
+        notKeywords.push(word)
+      }
+      options.match = notKeywords
 
       // skip rules with no match
       if (options.match.length === 0) {
@@ -305,11 +342,16 @@
         value = match[i + 1]
         if (value !== undefined) {
           group = groups[i]
+          // TODO is `buffer` being leaked here?
           break
         }
       }
       // assert(i < groupCount)
-      // TODO is `buffer` being leaked here?
+
+      // check for keywords
+      if (group.keywords) {
+        group = group.keywords[text] || group
+      }
     }
 
     // count line breaks

--- a/test/test.js
+++ b/test/test.js
@@ -18,18 +18,7 @@ describe('moo compiler', () => {
     expect(() => compile({ word: /foo/m })).toThrow()
   })
 
-  // TODO warns for multiple capture groups
-
-  // TODO wraps zero capture groups
-
   // TODO warns if no lineBreaks: true
-
-  test('sorts regexps and strings', () => {
-    let lexer = moo.compile({
-      tok: [/t[ok]+/, /\w/, 'tok', 'token']
-    })
-    expect(lexer.re.source.replace(/[(?:)]/g, '')).toBe('token|tok|t[ok]+|\\w')
-  })
 
   test('warns about missing states', () => {
     const rules = [
@@ -54,25 +43,46 @@ describe('moo compiler', () => {
     }
   })
 
-  test("deals with keyword literals", () => {
-    var keywordFirst = compile([
-      ['keyword',     ['class']],
-      ['identifier',  /[a-zA-Z]+/],
-    ])
-    expect(lexAll(keywordFirst.reset('class')).map(t => t.type)).toEqual(['keyword'])
-    expect(lexAll(keywordFirst.reset('className')).map(t => t.type)).toEqual(['identifier'])
+})
 
-    var identifierFirst = compile([
+describe('literals', () => {
+
+  // TODO test they're escaped
+
+  test('sorts regexps and strings', () => {
+    let lexer = moo.compile({
+      tok: [/t[ok]+/, /\w/, 'foo', 'token']
+    })
+    expect(lexer.re.source.replace(/[(?:)]/g, '')).toBe('token|foo|t[ok]+|\\w')
+  })
+
+  test("deals with keyword literals", () => {
+    function check(lexer) {
+      lexer.reset('class')
+      expect(lexer.next()).toMatchObject({ type: 'keyword', value: 'class' })
+      expect(lexer.next()).not.toBeTruthy()
+      lexer.reset('className')
+      expect(lexer.next()).toMatchObject({ type: 'identifier', value: 'className' })
+      expect(lexer.next()).not.toBeTruthy()
+    }
+
+    check(compile([
+      ['keyword',     ['class']],
+      ['identifier',  /[a-zA-Z]+/],
+    ]))
+    check(compile([
       ['identifier',  /[a-zA-Z]+/],
       ['keyword',     ['class']],
-    ])
-    expect(lexAll(identifierFirst.reset('class')).map(t => t.type)).toEqual(['keyword'])
-    expect(lexAll(identifierFirst.reset('className')).map(t => t.type)).toEqual(['identifier'])
+    ]))
   })
 
 })
 
 describe('capturing groups', () => {
+
+  // TODO warns for multiple capture groups
+
+  // TODO wraps zero capture groups
 
   test('compiles list of capturing RegExps', () => {
     expect(() => moo.compile({
@@ -136,13 +146,13 @@ describe('moo lexer', () => {
 
   test('accepts rules in an array', () => {
     const lexer = compile([
-      ['keyword', 'bob'],
+      ['keyword', 'Bob'],
       ['word', /[a-z]+/],
       ['number', /[0-9]+/],
       ['space', / +/],
     ])
-    lexer.reset('bob ducks are 123 bad')
-    expect(lexer.next()).toMatchObject({type: 'keyword', value: 'bob'})
+    lexer.reset('Bob ducks are 123 bad')
+    expect(lexer.next()).toMatchObject({type: 'keyword', value: 'Bob'})
     expect(lexer.next()).toMatchObject({type: 'space', value: ' '})
     expect(lexer.next()).toMatchObject({type: 'word', value: 'ducks'})
     expect(lexer.next()).toMatchObject({type: 'space', value: ' '})

--- a/test/test.js
+++ b/test/test.js
@@ -118,6 +118,20 @@ describe('moo lexer', () => {
     expect(lexer.next()).toMatchObject({type: 'space', value: ' '})
   })
 
+  test('accepts rules in an array', () => {
+    const lexer = compile([
+      ['keyword', 'bob'],
+      ['word', /[a-z]+/],
+      ['number', /[0-9]+/],
+      ['space', / +/],
+    ])
+    lexer.reset('bob ducks are 123 bad')
+    expect(lexer.next()).toMatchObject({type: 'keyword', value: 'bob'})
+    expect(lexer.next()).toMatchObject({type: 'space', value: ' '})
+    expect(lexer.next()).toMatchObject({type: 'word', value: 'ducks'})
+    expect(lexer.next()).toMatchObject({type: 'space', value: ' '})
+  })
+
   test('accepts a list of regexps', () => {
     const lexer = compile({
       number: [

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,22 @@ describe('moo compiler', () => {
     }
   })
 
+  test("deals with keyword literals", () => {
+    var keywordFirst = compile([
+      ['keyword',     ['class']],
+      ['identifier',  /[a-zA-Z]+/],
+    ])
+    expect(lexAll(keywordFirst.reset('class')).map(t => t.type)).toEqual(['keyword'])
+    expect(lexAll(keywordFirst.reset('className')).map(t => t.type)).toEqual(['identifier'])
+
+    var identifierFirst = compile([
+      ['identifier',  /[a-zA-Z]+/],
+      ['keyword',     ['class']],
+    ])
+    expect(lexAll(identifierFirst.reset('class')).map(t => t.type)).toEqual(['keyword'])
+    expect(lexAll(identifierFirst.reset('className')).map(t => t.type)).toEqual(['identifier'])
+  })
+
 })
 
 describe('capturing groups', () => {


### PR DESCRIPTION
Another go at #5.

Internally add `keywords` dict to rule options. We check this exists before using it, to avoid the dict lookup cost.

New PR since the internals have changed significantly since... 3 days ago :-)