### PR TITLE
Throw error for no matching state

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -307,7 +307,7 @@
     this.state = state
     var info = this.states[state]
     if (!info) {
-      throw new Error('No state with name ' + state + ' is defined.')
+      throw new Error('No state with name "' + state + '" is defined.')
     }
     this.groups = info.groups
     this.error = info.error

--- a/moo.js
+++ b/moo.js
@@ -306,6 +306,9 @@
     if (!state || this.state === state) return
     this.state = state
     var info = this.states[state]
+    if (!info) {
+      throw new Error('No state with name ' + state + ' is defined.')
+    }
     this.groups = info.groups
     this.error = info.error
     this.re = info.regexp


### PR DESCRIPTION
- [x] Throw an error when there is no matching state for a state transition.