### PR TITLE
Accept a list of match objects

### DIFF
--- a/moo.js
+++ b/moo.js
@@ -38,6 +38,7 @@
   /***************************************************************************/
 
   function isRegExp(o) { return o && o.constructor === RegExp }
+  function isObject(o) { return o && typeof o === 'object' && o.constructor !== RegExp && !Array.isArray(o) }
 
   function reEscape(s) {
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
@@ -82,7 +83,11 @@
     var result = []
     for (var i=0; i<keys.length; i++) {
       var key = keys[i]
-      result.push(ruleOptions(key, object[key]))
+      var thing = object[key]
+      var rules = Array.isArray(thing) && (thing.length === 0 || isObject(thing[0])) ? thing : [thing]
+      rules.forEach(function(rule) {
+        result.push(ruleOptions(key, rule))
+      })
     }
     return result
   }

--- a/moo.js
+++ b/moo.js
@@ -84,10 +84,18 @@
     for (var i=0; i<keys.length; i++) {
       var key = keys[i]
       var thing = object[key]
-      var rules = Array.isArray(thing) && (thing.length === 0 || isObject(thing[0])) ? thing : [thing]
+      var rules = Array.isArray(thing) ? thing : [thing]
+      var match = []
       rules.forEach(function(rule) {
-        result.push(ruleOptions(key, rule))
+        if (isObject(rule)) {
+          if (match.length) result.push(ruleOptions(key, match))
+          result.push(ruleOptions(key, rule))
+          match = []
+        } else {
+          match.push(rule)
+        }
       })
+      if (match.length) result.push(ruleOptions(key, match))
     }
     return result
   }

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,17 @@ describe('compiler', () => {
     expect(lexer.next()).toMatchObject({type: 'space', value: ' '})
   })
 
+  test('accepts a list of match objects', () => {
+    const lexer = compile({
+      op: [
+        {match: '('},
+        {match: ')'},
+      ],
+    })
+    lexer.reset('())(')
+    expect(Array.from(lexer).map(x => x.value)).toEqual(['(', ')', ')', '('])
+  })
+
   test('accepts rules in an array', () => {
     const lexer = compile([
       { name: 'keyword', match: 'Bob'},

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,21 @@ describe('compiler', () => {
     expect(Array.from(lexer).map(x => x.value)).toEqual(['(', ')', ')', '('])
   })
 
+  test('accepts mixed rules and match objects', () => {
+    const lexer = compile({
+      op: [
+        /regexp/,
+        'string',
+        {match: /something/},
+        'lol',
+      ],
+    })
+    expect(lexer.groups.length).toBe(3)
+    expect(lexer.reset('string').next()).toMatchObject({type: 'op', value: 'string'})
+    expect(lexer.reset('regexp').next()).toMatchObject({type: 'op', value: 'regexp'})
+    expect(lexer.reset('something').next()).toMatchObject({type: 'op', value: 'something'})
+  })
+
   test('accepts rules in an array', () => {
     const lexer = compile([
       { name: 'keyword', match: 'Bob'},


### PR DESCRIPTION
This allows writing rules in the object style, where the rules have the same `tokenType` but different properties (e.g. `lineBreaks`, or state manipulation).

e.g.

```js
  STRING: [
    {match: /"""[^]*?"""/, lineBreaks: true},
    {match: /"(?:\\["\\]|[^"\\\n])*?"/},
    {match: /'(?:\\['\\]|[^'\\\n])*?'/},
  ],
```
